### PR TITLE
chore: upgrade terraform syntax to 0.12

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -3,34 +3,45 @@
 - Manually allow egress and ingress to the API endpoints
 - Optional VPCE for AWS API
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| nomad | n/a |
+| template | n/a |
+| vault | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| asg_name | Name of the Nomad Client Autoscaling group | string | - | yes |
-| auth_path | Path the Vault AWS authentication engine | string | `aws` | no |
-| auth_role | Name of the Role that the AWS Lambda will use to authenticate with Vault | string | `nomad_drain_lambda` | no |
-| aws_auth_header_value | Header value that must be included when authenticating via AWS, if set | string | `` | no |
-| lambda_description | Lanbda description text | string | `Automatically drain a Nomad node of allocations when the instance is terminating.` | no |
-| lambda_name | Name of the Nomad Drain Lambda | string | `nomad_node_drain` | no |
-| lambda_timeout | Lambda Timeout in seconds. Maximum is 900 | string | `900` | no |
-| lifecycle_hook_name | Name of the lifecycle hook | string | `nomad_client_drain` | no |
-| nomad_acl_policy_name | Name of the Nomad ACL policy to allow the Lambda to drain nodes | string | `LambdaDrain` | no |
-| nomad_address | Address to Nomad Server API | string | - | yes |
-| nomad_api_port | Port for the Nomad API | string | `4646` | no |
-| nomad_path | Path to the Vault's Nomad secrets engine | string | `nomad` | no |
-| nomad_role | Name of the role for the lambda to retrieve Nomad Token | string | `nomad_drain_lambda` | no |
-| nomad_server_security_group | Security Group ID for Nomad servers | string | - | yes |
-| tags | Map of tags for resources | string | `<map>` | no |
-| vault_address | Address to Vault API | string | - | yes |
-| vault_api_port | Port for Vault API | string | `8200` | no |
-| vault_policy_name | Name of the Vault Policy to allow the lambda to retrieve Nomad tokens | string | `nomad_drain_lambda` | no |
-| vault_security_group | Security Group ID for Vault | string | - | yes |
-| vpc_id | VPC ID to run the lambda in | string | - | yes |
-| vpc_subnets | VPC Subnet IDs to run the lambda in | list | - | yes |
+|------|-------------|------|---------|:-----:|
+| asg\_name | Name of the Nomad Client Autoscaling group | `any` | n/a | yes |
+| auth\_path | Path the Vault AWS authentication engine | `string` | `"aws"` | no |
+| auth\_role | Name of the Role that the AWS Lambda will use to authenticate with Vault | `string` | `"nomad_drain_lambda"` | no |
+| aws\_auth\_header\_value | Header value that must be included when authenticating via AWS, if set | `string` | `""` | no |
+| enable\_backtrace | Enable backtrace generation during errors | `bool` | `false` | no |
+| lambda\_description | Lanbda description text | `string` | `"Automatically drain a Nomad node of allocations when the instance is terminating."` | no |
+| lambda\_name | Name of the Nomad Drain Lambda | `string` | `"nomad_node_drain"` | no |
+| lambda\_payload | Path to the Lambda payload. The payload must be zipped with the binary named `bootstrap`. It must be compiled for the target `x86_64-unknown-linux-musl` | `any` | n/a | yes |
+| lambda\_timeout | Lambda Timeout in seconds. Maximum is 900 | `number` | `900` | no |
+| lifecycle\_hook\_name | Name of the lifecycle hook | `string` | `"nomad_client_drain"` | no |
+| lifecycle\_hook\_timeout | Maximum amount of time the lifecycle hook is allowed to run in seconds. | `number` | `900` | no |
+| log\_level | Log level for the Lambda. Refer to https://docs.rs/env_logger/0.6.0/env_logger/#enabling-logging for details. | `string` | `"nomad_drain=info,bootstrap=info"` | no |
+| nomad\_acl\_policy\_name | Name of the Nomad ACL policy to allow the Lambda to drain nodes | `string` | `"LambdaDrain"` | no |
+| nomad\_address | Address to Nomad Server API | `any` | n/a | yes |
+| nomad\_path | Path to the Vault's Nomad secrets engine | `string` | `"nomad"` | no |
+| nomad\_role | Name of the role for the lambda to retrieve Nomad Token | `string` | `"nomad_drain_lambda"` | no |
+| notification\_metadata | Additional Metadata to pass to the Lambda on notification | `string` | `""` | no |
+| tags | Map of tags for resources | `map` | <pre>{<br>  "Terraform": "true"<br>}<br></pre> | no |
+| vault\_address | Address to Vault API | `any` | n/a | yes |
+| vault\_policy\_name | Name of the Vault Policy to allow the lambda to retrieve Nomad tokens | `string` | `"nomad_drain_lambda"` | no |
+| vpc\_id | VPC ID to run the lambda in | `any` | n/a | yes |
+| vpc\_subnets | VPC Subnet IDs to run the lambda in | `list(string)` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| lambda_security_group_id | Security Group ID for the Lambda Function |
+| lambda\_iam\_role | Name of the IAM Role for the lambda |
+| lambda\_security\_group\_id | Security Group ID for the Lambda Function |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,10 +1,10 @@
 # Reference: https://docs.aws.amazon.com/autoscaling/ec2/userguide/lifecycle-hooks.html
 locals {
-  lambda_payload_path = "${var.lambda_payload}"
+  lambda_payload_path = var.lambda_payload
 }
 
 data "aws_autoscaling_group" "asg" {
-  name = "${var.asg_name}"
+  name = var.asg_name
 }
 
 data "aws_iam_policy_document" "lambda_assume_role" {
@@ -19,79 +19,79 @@ data "aws_iam_policy_document" "lambda_assume_role" {
 }
 
 resource "aws_iam_role" "lambda" {
-  name = "${var.lambda_name}"
+  name = var.lambda_name
 
-  assume_role_policy = "${data.aws_iam_policy_document.lambda_assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 }
 
 resource "aws_iam_role_policy" "asg_lifecycle" {
-  role   = "${aws_iam_role.lambda.id}"
-  policy = "${data.aws_iam_policy_document.asg_lifecycle.json}"
+  role   = aws_iam_role.lambda.id
+  policy = data.aws_iam_policy_document.asg_lifecycle.json
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_logging" {
-  role       = "${aws_iam_role.lambda.id}"
+  role       = aws_iam_role.lambda.id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
 # See https://forums.aws.amazon.com/message.jspa?messageID=756727
 # and https://docs.aws.amazon.com/lambda/latest/dg/vpc.html
 resource "aws_iam_role_policy_attachment" "lambda_eni" {
-  role       = "${aws_iam_role.lambda.id}"
+  role       = aws_iam_role.lambda.id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaENIManagementAccess"
 }
 
 resource "aws_security_group" "lambda" {
-  name                   = "${var.lambda_name}"
+  name                   = var.lambda_name
   description            = "Security group for the ${var.lambda_name} lambda function"
-  vpc_id                 = "${var.vpc_id}"
+  vpc_id                 = var.vpc_id
   revoke_rules_on_delete = true
 
-  tags = "${merge(var.tags, map("Name", var.lambda_name))}"
+  tags = merge(var.tags, { Name = var.lambda_name })
 }
 
 resource "aws_lambda_function" "drain" {
   depends_on = [
-    "aws_iam_role_policy_attachment.lambda_logging",
-    "aws_iam_role_policy_attachment.lambda_eni",
+    aws_iam_role_policy_attachment.lambda_logging,
+    aws_iam_role_policy_attachment.lambda_eni,
   ]
 
-  filename         = "${local.lambda_payload_path}"
-  source_code_hash = "${base64sha256(file("${local.lambda_payload_path}"))}"
+  filename         = local.lambda_payload_path
+  source_code_hash = filebase64sha256(local.lambda_payload_path)
 
-  function_name = "${var.lambda_name}"
-  role          = "${aws_iam_role.lambda.arn}"
-  description   = "${var.lambda_description}"
+  function_name = var.lambda_name
+  role          = aws_iam_role.lambda.arn
+  description   = var.lambda_description
 
   handler = "doesnt_matter"
   runtime = "provided"
-  timeout = "${var.lambda_timeout}"
+  timeout = var.lambda_timeout
 
   vpc_config {
-    subnet_ids         = ["${var.vpc_subnets}"]
-    security_group_ids = ["${aws_security_group.lambda.id}"]
+    subnet_ids         = var.vpc_subnets
+    security_group_ids = [aws_security_group.lambda.id]
   }
 
   environment {
-    variables {
-      NOMAD_ADDR        = "${var.nomad_address}"
+    variables = {
+      NOMAD_ADDR        = var.nomad_address
       USE_NOMAD_TOKEN   = "true"
-      VAULT_ADDR        = "${var.vault_address}"
-      AUTH_PATH         = "${var.auth_path}"
-      AUTH_ROLE         = "${vault_aws_auth_backend_role.lambda.role}"
-      AUTH_HEADER_VALUE = "${var.aws_auth_header_value}"
-      NOMAD_PATH        = "${var.nomad_path}"
-      NOMAD_ROLE        = "${var.nomad_role}"
-      RUST_LOG          = "${var.log_level}"
-      RUST_BACKTRACE    = "${var.enable_backtrace ? "1": "0"}"
+      VAULT_ADDR        = var.vault_address
+      AUTH_PATH         = var.auth_path
+      AUTH_ROLE         = vault_aws_auth_backend_role.lambda.role
+      AUTH_HEADER_VALUE = var.aws_auth_header_value
+      NOMAD_PATH        = var.nomad_path
+      NOMAD_ROLE        = var.nomad_role
+      RUST_LOG          = var.log_level
+      RUST_BACKTRACE    = var.enable_backtrace ? "1" : "0"
     }
   }
 
-  tags = "${var.tags}"
+  tags = var.tags
 }
 
 resource "aws_cloudwatch_event_rule" "drain" {
-  name        = "${var.lambda_name}"
+  name        = var.lambda_name
   description = "Invoke Lambda named ${var.lambda_name} when the ASG ${var.asg_name} terminates instances to drain Nomad nodes of allocations"
 
   event_pattern = <<EOF
@@ -109,15 +109,15 @@ EOF
 
 resource "aws_lambda_permission" "cloudwatch_events" {
   action              = "lambda:InvokeFunction"
-  function_name       = "${aws_lambda_function.drain.function_name}"
+  function_name       = aws_lambda_function.drain.function_name
   principal           = "events.amazonaws.com"
-  source_arn          = "${aws_cloudwatch_event_rule.drain.arn}"
-  statement_id_prefix = "${var.lambda_name}"
+  source_arn          = aws_cloudwatch_event_rule.drain.arn
+  statement_id_prefix = var.lambda_name
 }
 
 resource "aws_cloudwatch_event_target" "drain_lambda" {
-  rule = "${aws_cloudwatch_event_rule.drain.name}"
-  arn  = "${aws_lambda_function.drain.arn}"
+  rule = aws_cloudwatch_event_rule.drain.name
+  arn  = aws_lambda_function.drain.arn
 }
 
 data "aws_iam_policy_document" "asg_lifecycle" {
@@ -127,16 +127,16 @@ data "aws_iam_policy_document" "asg_lifecycle" {
     ]
 
     resources = [
-      "${data.aws_autoscaling_group.asg.arn}",
+      data.aws_autoscaling_group.asg.arn,
     ]
   }
 }
 
 resource "aws_autoscaling_lifecycle_hook" "terminate" {
-  name                   = "${var.lambda_name}"
-  autoscaling_group_name = "${var.asg_name}"
+  name                   = var.lambda_name
+  autoscaling_group_name = var.asg_name
   default_result         = "CONTINUE"
   lifecycle_transition   = "autoscaling:EC2_INSTANCE_TERMINATING"
-  notification_metadata  = "${var.notification_metadata}"
-  heartbeat_timeout      = "${var.lifecycle_hook_timeout}"
+  notification_metadata  = var.notification_metadata
+  heartbeat_timeout      = var.lifecycle_hook_timeout
 }

--- a/terraform/nomad.tf
+++ b/terraform/nomad.tf
@@ -1,5 +1,5 @@
 resource "nomad_acl_policy" "lambda" {
-  name        = "${var.nomad_acl_policy_name}"
+  name        = var.nomad_acl_policy_name
   description = "Allow an AWS Lambda to drain Nomad nodes on termination"
-  rules_hcl   = "${file("${path.module}/nomad/policy.hcl")}"
+  rules_hcl   = file("${path.module}/nomad/policy.hcl")
 }

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,9 +1,9 @@
 output "lambda_security_group_id" {
   description = "Security Group ID for the Lambda Function"
-  value       = "${aws_security_group.lambda.id}"
+  value       = aws_security_group.lambda.id
 }
 
 output "lambda_iam_role" {
   description = "Name of the IAM Role for the lambda"
-  value       = "${aws_iam_role.lambda.name}"
+  value       = aws_iam_role.lambda.name
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -8,7 +8,7 @@ variable "vpc_id" {
 
 variable "vpc_subnets" {
   description = "VPC Subnet IDs to run the lambda in"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "nomad_address" {
@@ -102,7 +102,7 @@ variable "notification_metadata" {
 variable "tags" {
   description = "Map of tags for resources"
 
-  default {
+  default = {
     Terraform = "true"
   }
 }

--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -1,36 +1,42 @@
-data "template_file" "nomad_lambda_role" {
-  template = "${file("${path.module}/vault/nomad_role.json")}"
+terraform {
+  required_providers {
+    vault = ">= 1.2"
+  }
+}
 
-  vars {
-    lambda_policy_name = "${nomad_acl_policy.lambda.name}"
+data "template_file" "nomad_lambda_role" {
+  template = file("${path.module}/vault/nomad_role.json")
+
+  vars = {
+    lambda_policy_name = nomad_acl_policy.lambda.name
   }
 }
 
 resource "vault_generic_secret" "nomad_lambda_role" {
   path      = "${var.nomad_path}/role/${var.nomad_role}"
-  data_json = "${data.template_file.nomad_lambda_role.rendered}"
+  data_json = data.template_file.nomad_lambda_role.rendered
 }
 
 data "template_file" "vault_policy" {
-  template = "${file("${path.module}/vault/policy.hcl")}"
+  template = file("${path.module}/vault/policy.hcl")
 
-  vars {
-    nomad_path = "${var.nomad_path}"
-    nomad_role = "${var.nomad_role}"
+  vars = {
+    nomad_path = var.nomad_path
+    nomad_role = var.nomad_role
   }
 }
 
 resource "vault_policy" "nomad_lambda" {
-  name   = "${var.vault_policy_name}"
-  policy = "${data.template_file.vault_policy.rendered}"
+  name   = var.vault_policy_name
+  policy = data.template_file.vault_policy.rendered
 }
 
 resource "vault_aws_auth_backend_role" "lambda" {
-  backend                  = "${var.auth_path}"
-  role                     = "${var.auth_role}"
+  backend                  = var.auth_path
+  role                     = var.auth_role
   auth_type                = "iam"
-  bound_iam_principal_arns = ["${aws_iam_role.lambda.arn}"]
-  ttl                      = "${var.lambda_timeout}"
-  max_ttl                  = "${var.lambda_timeout}"
-  policies                 = ["${vault_policy.nomad_lambda.name}"]
+  bound_iam_principal_arns = [aws_iam_role.lambda.arn]
+  token_ttl                = var.lambda_timeout
+  token_max_ttl            = var.lambda_timeout
+  token_policies           = [vault_policy.nomad_lambda.name]
 }


### PR DESCRIPTION
Upgrade the terraform module to 0.12 syntax.

Vault provider has a minimal version requirement to ensure no deprecated
fields are used.

BREAKING CHANGE: The terraform module is only usable from 0.12 onwards.